### PR TITLE
Remove bad method call to google api for 2fa

### DIFF
--- a/src/TwoFactorAuthController.php
+++ b/src/TwoFactorAuthController.php
@@ -34,8 +34,6 @@ class TwoFactorAuthController extends Controller
      */
     public function generate(Request $request)
     {
-        $this->g2fa->setAllowInsecureCallToGoogleApis(true);
-
         $secret = $this->g2fa->generateSecretKey();
 
         $request->session()->put('spark:twofactor:secret', $secret);


### PR DESCRIPTION
We are removing the `setAllowInsecureCallToGoogleApis` call that recently broke for the initial laravel-spark-google2fa.

I'm now referencing the Simpleweb fork of the package in tap.